### PR TITLE
Add Flask app with health check and tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,64 @@
+import os
+from flask import Flask, jsonify, send_from_directory
+
+
+class DataManager:
+    """Simple data manager stub with start/stop hooks."""
+
+    def __init__(self):
+        self.started = False
+
+    def start(self):
+        self.started = True
+
+    def stop(self):
+        self.started = False
+
+
+def create_app():
+    """Application factory for the Telegram alert service."""
+    base_dir = os.path.abspath(os.path.dirname(__file__))
+    app = Flask(__name__, static_folder=os.path.join(base_dir, 'static'))
+
+    # Database directory
+    db_dir = os.path.join(base_dir, 'database')
+    os.makedirs(db_dir, exist_ok=True)
+    app.config['DB_DIR'] = db_dir
+
+    data_manager = DataManager()
+    data_manager.start()
+
+    @app.route('/api/alerts/generate', methods=['POST'])
+    def generate_and_send_alerts():
+        # Placeholder implementation: no real alerts are generated yet.
+        return jsonify({"status": "success", "alerts_generated": 0, "alerts_sent": 0}), 200
+
+    @app.route('/healthz')
+    def health():
+        return jsonify({"ok": True}), 200
+
+    @app.route('/', defaults={'path': ''})
+    @app.route('/<path:path>')
+    def serve(path):
+        static_folder = app.static_folder
+        if not static_folder or not os.path.isdir(static_folder):
+            return "Static folder not configured", 404
+        requested = os.path.join(static_folder, path)
+        if path and os.path.exists(requested):
+            return send_from_directory(static_folder, path)
+        index_path = os.path.join(static_folder, 'index.html')
+        if os.path.exists(index_path):
+            return send_from_directory(static_folder, 'index.html')
+        return "index.html not found", 404
+
+    @app.teardown_appcontext
+    def cleanup(exception=None):
+        if data_manager.started:
+            data_manager.stop()
+
+    return app
+
+
+if __name__ == '__main__':
+    app = create_app()
+    app.run(host=os.getenv('HOST', '0.0.0.0'), port=int(os.getenv('PORT', '5000')))

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,32 @@
+import os
+import sys
+
+# Ensure the repository root is on the Python path so ``import app`` works
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import app
+
+
+def test_healthz():
+    flask_app = app.create_app()
+    client = flask_app.test_client()
+    resp = client.get('/healthz')
+    assert resp.status_code == 200
+    assert resp.get_json() == {"ok": True}
+
+
+def test_static_index_served(tmp_path):
+    flask_app = app.create_app()
+    static_folder = flask_app.static_folder
+    os.makedirs(static_folder, exist_ok=True)
+    index_path = os.path.join(static_folder, 'index.html')
+    with open(index_path, 'w', encoding='utf-8') as f:
+        f.write('ok')
+    client = flask_app.test_client()
+    resp = client.get('/')
+    assert resp.status_code == 200
+    os.remove(index_path)
+
+
+def test_db_dir_exists():
+    flask_app = app.create_app()
+    assert os.path.isdir(flask_app.config['DB_DIR'])


### PR DESCRIPTION
## Summary
- add a minimal Flask application with DataManager stub and cleanup
- provide tests for health check, static serving, and database directory

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6429fd33483228c7977ecbfb73099