### PR TITLE
refactor: remove side-effect-only import

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,13 +1,12 @@
 import os
 import sys
 
-# Ensure the repository root is on the Python path so ``import app`` works
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-import app
+from app import create_app
 
 
 def test_healthz():
-    flask_app = app.create_app()
+    flask_app = create_app()
     client = flask_app.test_client()
     resp = client.get('/healthz')
     assert resp.status_code == 200
@@ -15,7 +14,7 @@ def test_healthz():
 
 
 def test_static_index_served(tmp_path):
-    flask_app = app.create_app()
+    flask_app = create_app()
     static_folder = flask_app.static_folder
     os.makedirs(static_folder, exist_ok=True)
     index_path = os.path.join(static_folder, 'index.html')
@@ -28,5 +27,5 @@ def test_static_index_served(tmp_path):
 
 
 def test_db_dir_exists():
-    flask_app = app.create_app()
+    flask_app = create_app()
     assert os.path.isdir(flask_app.config['DB_DIR'])


### PR DESCRIPTION
## Summary
- replace blanket `import app` with explicit `from app import create_app`
- drop unused path-comment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b6613046588322b049851cece47623