### PR TITLE
Add simulated commute prediction endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 import os
 from flask import Flask, jsonify, send_from_directory
+from commute import generate_commute_data
 
 
 class DataManager:
@@ -36,6 +37,11 @@ def create_app():
     @app.route('/healthz')
     def health():
         return jsonify({"ok": True}), 200
+
+    @app.route('/api/commute')
+    def commute_summary():
+        """Provide a simulated predictive commute summary."""
+        return jsonify(generate_commute_data())
 
     @app.route('/', defaults={'path': ''})
     @app.route('/<path:path>')

--- a/commute.py
+++ b/commute.py
@@ -1,0 +1,32 @@
+import datetime
+from typing import List, Dict
+
+def _traffic_prediction(now: datetime.datetime) -> List[Dict[str, int]]:
+    """Return a simple traffic speed prediction for the next hour."""
+    points = []
+    for minutes in range(0, 61, 15):
+        time_label = (now + datetime.timedelta(minutes=minutes)).strftime('%H:%M')
+        speed = max(10, 50 - (minutes // 15) * 5)
+        points.append({"time": time_label, "speed_kmh": speed})
+    return points
+
+def generate_commute_data() -> Dict:
+    """Simulate predictive commute data."""
+    now = datetime.datetime.now().replace(second=0, microsecond=0)
+    return {
+        "route_name": "Your Evening Drive",
+        "eta_minutes": 28,
+        "eta_vs_average": 2,
+        "weather": "Clear",
+        "alerts": [
+            {"message": "Minor delay near Sycamore Rd", "delay_min": 5},
+            {"message": "All clear on Main St Bypass"},
+        ],
+        "traffic_prediction": _traffic_prediction(now),
+        "historical_pattern": [
+            {"time": "17:00", "speed_kmh": 45},
+            {"time": "18:00", "speed_kmh": 40},
+        ],
+    }
+
+__all__ = ["generate_commute_data"]

--- a/tests/test_commute.py
+++ b/tests/test_commute.py
@@ -1,0 +1,23 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from app import create_app
+
+def test_commute_endpoint():
+    app = create_app()
+    client = app.test_client()
+    resp = client.get('/api/commute')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    for key in [
+        'route_name',
+        'eta_minutes',
+        'eta_vs_average',
+        'weather',
+        'alerts',
+        'traffic_prediction',
+        'historical_pattern',
+    ]:
+        assert key in data
+    assert isinstance(data['traffic_prediction'], list) and data['traffic_prediction']


### PR DESCRIPTION
## Summary
- add `generate_commute_data` helper to simulate predictive commute info
- expose `/api/commute` endpoint serving commute summary
- test commute endpoint for required fields

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb94c0b598832295736948b17df86b