### PR TITLE
Add static React simulator interface

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,827 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>5G Window Placement Simulator — Wilmington &amp; Leland</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+      body {
+        margin: 0;
+        background-color: #0a0a0a;
+        color: #f5f5f5;
+        font-family: 'Inter', 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      }
+      canvas {
+        display: block;
+      }
+    </style>
+  </head>
+  <body class="bg-neutral-950 text-neutral-100">
+    <div id="root"></div>
+
+    <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
+    <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
+    <script src="https://unpkg.com/three@0.160.0/build/three.min.js"></script>
+    <script src="https://unpkg.com/three@0.160.0/examples/js/controls/OrbitControls.js"></script>
+    <script src="https://unpkg.com/recharts/umd/Recharts.min.js"></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+
+    <script type="text/babel" data-presets="env,react">
+      const { useEffect, useMemo, useRef, useState, useCallback } = React;
+      const {
+        LineChart,
+        Line,
+        Tooltip,
+        XAxis,
+        YAxis,
+        CartesianGrid,
+        ResponsiveContainer,
+        Legend,
+        RadarChart,
+        PolarGrid,
+        PolarAngleAxis,
+        PolarRadiusAxis,
+        Radar,
+      } = Recharts;
+      const OrbitControls = THREE.OrbitControls;
+
+      const TOWER_PRESETS = {
+        '1270 Dunlop Dr (Leland)': {
+          verizon: { bearingDeg: 45, distanceKm: 1.2, band: 'n77' },
+          att: { bearingDeg: 200, distanceKm: 2.5, band: 'n5/n77' },
+        },
+        '211 Watauga Rd (Wilmington)': {
+          verizon: { bearingDeg: 120, distanceKm: 1.8, band: 'n77' },
+          att: { bearingDeg: 300, distanceKm: 3.2, band: 'n77' },
+        },
+      };
+
+      function degToRad(d) {
+        return (d * Math.PI) / 180;
+      }
+      function clamp(v, min, max) {
+        return Math.max(min, Math.min(max, v));
+      }
+
+      function bearingToXY(deg, r = 1) {
+        const rad = degToRad(deg);
+        return { x: Math.cos(rad) * r, y: Math.sin(rad) * r };
+      }
+
+      function downloadCSV(rows, filename = '5g_measurements.csv') {
+        const header = [
+          'timestamp',
+          'address',
+          'carrier',
+          'bearing_deg',
+          'location',
+          'down_mbps',
+          'up_mbps',
+          'latency_ms',
+          'rsrp_dbm',
+          'sinr_db',
+          'notes',
+        ];
+        const esc = (s) => `"${String(s ?? '').replace(/"/g, '""')}"`;
+        const csv = [header.join(',')]
+          .concat(
+            rows.map((r) =>
+              [
+                new Date(r.ts).toISOString(),
+                r.address,
+                r.carrier,
+                r.bearing,
+                r.location,
+                r.down,
+                r.up,
+                r.lat,
+                r.rsrp,
+                r.sinr,
+                r.notes,
+              ]
+                .map(esc)
+                .join(',')
+            )
+          )
+          .join('\n');
+        const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        a.click();
+        URL.revokeObjectURL(url);
+      }
+
+      function useSignalScene(canvasRef, options) {
+        const { verizonBearing, attBearing, userFacingDeg, showATT, showVerizon } = options;
+        const requestRef = useRef();
+        const objectsRef = useRef({});
+
+        useEffect(() => {
+          const canvas = canvasRef.current;
+          if (!canvas) {
+            return undefined;
+          }
+
+          const renderer = new THREE.WebGLRenderer({ canvas, antialias: true, alpha: true });
+          renderer.setPixelRatio(window.devicePixelRatio || 1);
+          renderer.setSize(canvas.clientWidth, canvas.clientHeight, false);
+
+          const scene = new THREE.Scene();
+          scene.background = null;
+
+          const camera = new THREE.PerspectiveCamera(
+            45,
+            canvas.clientWidth / canvas.clientHeight,
+            0.1,
+            1000
+          );
+          camera.position.set(4, 4.5, 6.5);
+
+          const controls = new OrbitControls(camera, renderer.domElement);
+          controls.enableDamping = true;
+          controls.dampingFactor = 0.08;
+          controls.target.set(0, 0.75, 0);
+
+          const ambient = new THREE.AmbientLight(0xffffff, 0.9);
+          scene.add(ambient);
+          const dirLight = new THREE.DirectionalLight(0xffffff, 0.6);
+          dirLight.position.set(5, 10, 7);
+          scene.add(dirLight);
+
+          const grid = new THREE.GridHelper(10, 10, 0x777777, 0x333333);
+          grid.position.y = 0;
+          scene.add(grid);
+
+          const house = new THREE.Group();
+          const baseGeo = new THREE.BoxGeometry(1.8, 1.2, 1.2);
+          const baseMat = new THREE.MeshStandardMaterial({
+            color: 0x6b7280,
+            metalness: 0.1,
+            roughness: 0.8,
+          });
+          const base = new THREE.Mesh(baseGeo, baseMat);
+          base.position.y = 0.6;
+          house.add(base);
+          const roofGeo = new THREE.ConeGeometry(1.3, 0.6, 4);
+          const roofMat = new THREE.MeshStandardMaterial({
+            color: 0x374151,
+            metalness: 0.2,
+            roughness: 0.7,
+          });
+          const roof = new THREE.Mesh(roofGeo, roofMat);
+          roof.position.y = 1.5;
+          roof.rotation.y = Math.PI / 4;
+          house.add(roof);
+          scene.add(house);
+
+          const ring = new THREE.RingGeometry(2.2, 2.25, 64);
+          const ringMat = new THREE.MeshBasicMaterial({ color: 0x9ca3af, side: THREE.DoubleSide });
+          const ringMesh = new THREE.Mesh(ring, ringMat);
+          ringMesh.rotation.x = -Math.PI / 2;
+          scene.add(ringMesh);
+
+          function addDirMarker(color, bearingDeg, name) {
+            const group = new THREE.Group();
+            const cyl = new THREE.Mesh(
+              new THREE.CylinderGeometry(0.03, 0.03, 1.6, 16),
+              new THREE.MeshStandardMaterial({ color, metalness: 0.3, roughness: 0.5 })
+            );
+            cyl.position.y = 0.8;
+            group.add(cyl);
+            const head = new THREE.Mesh(
+              new THREE.ConeGeometry(0.12, 0.3, 24),
+              new THREE.MeshStandardMaterial({ color })
+            );
+            head.position.y = 1.75;
+            group.add(head);
+            const { x, y } = bearingToXY(bearingDeg, 2.2);
+            group.position.set(x, 0, y);
+            group.lookAt(0, 0.8, 0);
+            scene.add(group);
+            objectsRef.current[name] = group;
+          }
+
+          addDirMarker(0xef4444, verizonBearing, 'vzMarker');
+          addDirMarker(0x3b82f6, attBearing, 'attMarker');
+
+          const userRay = new THREE.Mesh(
+            new THREE.CylinderGeometry(0.01, 0.01, 2.4, 8),
+            new THREE.MeshBasicMaterial({ color: 0x22c55e })
+          );
+          userRay.position.y = 1.2;
+          userRay.rotation.z = Math.PI / 2;
+          scene.add(userRay);
+          objectsRef.current.userRay = userRay;
+
+          function onResize() {
+            const width = canvas.clientWidth;
+            const height = canvas.clientHeight;
+            renderer.setSize(width, height, false);
+            camera.aspect = width / height;
+            camera.updateProjectionMatrix();
+          }
+
+          let ro;
+          if (typeof ResizeObserver !== 'undefined') {
+            ro = new ResizeObserver(onResize);
+            ro.observe(canvas);
+          } else {
+            window.addEventListener('resize', onResize);
+          }
+
+          const animate = () => {
+            requestRef.current = requestAnimationFrame(animate);
+            controls.update();
+            renderer.render(scene, camera);
+          };
+          animate();
+
+          return () => {
+            cancelAnimationFrame(requestRef.current);
+            controls.dispose();
+            renderer.dispose();
+            if (ro) {
+              ro.disconnect();
+            } else {
+              window.removeEventListener('resize', onResize);
+            }
+            scene.traverse((obj) => {
+              if (obj.geometry) {
+                obj.geometry.dispose?.();
+              }
+              if (obj.material) {
+                if (Array.isArray(obj.material)) {
+                  obj.material.forEach((m) => m.dispose?.());
+                } else {
+                  obj.material.dispose?.();
+                }
+              }
+            });
+          };
+        }, []);
+
+        useEffect(() => {
+          const { vzMarker, attMarker, userRay } = objectsRef.current;
+          if (vzMarker) {
+            vzMarker.visible = !!showVerizon;
+            const { x, y } = bearingToXY(verizonBearing, 2.2);
+            vzMarker.position.set(x, 0, y);
+            vzMarker.lookAt(0, 0.8, 0);
+          }
+          if (attMarker) {
+            attMarker.visible = !!showATT;
+            const { x, y } = bearingToXY(attBearing, 2.2);
+            attMarker.position.set(x, 0, y);
+            attMarker.lookAt(0, 0.8, 0);
+          }
+          if (userRay) {
+            const deg = (userFacingDeg + 90) % 360;
+            userRay.rotation.y = degToRad(deg);
+          }
+        }, [verizonBearing, attBearing, userFacingDeg, showATT, showVerizon]);
+      }
+
+      function WindowPlacementSimulator() {
+        const [address, setAddress] = useState('1270 Dunlop Dr (Leland)');
+        const [showVerizon, setShowVerizon] = useState(true);
+        const [showATT, setShowATT] = useState(true);
+
+        const preset = TOWER_PRESETS[address];
+        const [vzBearing, setVzBearing] = useState(preset.verizon.bearingDeg);
+        const [attBearing, setAttBearing] = useState(preset.att.bearingDeg);
+
+        useEffect(() => {
+          const p = TOWER_PRESETS[address];
+          setVzBearing(p.verizon.bearingDeg);
+          setAttBearing(p.att.bearingDeg);
+        }, [address]);
+
+        const [facing, setFacing] = useState(0);
+        const [useCompass, setUseCompass] = useState(false);
+        const compassHandlerRef = useRef(null);
+
+        const requestCompass = useCallback(async () => {
+          try {
+            const anyWin = window;
+            const needsPerm =
+              typeof anyWin.DeviceOrientationEvent !== 'undefined' &&
+              typeof anyWin.DeviceOrientationEvent.requestPermission === 'function';
+            if (needsPerm) {
+              const perm = await anyWin.DeviceOrientationEvent.requestPermission();
+              if (perm !== 'granted') {
+                return;
+              }
+            }
+            if (!compassHandlerRef.current) {
+              const handler = (event) => {
+                if (event && typeof event.alpha === 'number') {
+                  const heading = 360 - event.alpha;
+                  const normalized = ((heading % 360) + 360) % 360;
+                  setFacing(normalized);
+                }
+              };
+              compassHandlerRef.current = handler;
+              window.addEventListener('deviceorientation', handler, true);
+            }
+            setUseCompass(true);
+          } catch (error) {
+            console.warn('Compass not available:', error);
+          }
+        }, []);
+
+        const stopCompass = useCallback(() => {
+          setUseCompass(false);
+          if (compassHandlerRef.current) {
+            window.removeEventListener('deviceorientation', compassHandlerRef.current, true);
+            compassHandlerRef.current = null;
+          }
+        }, []);
+
+        useEffect(() => {
+          return () => {
+            if (compassHandlerRef.current) {
+              window.removeEventListener('deviceorientation', compassHandlerRef.current, true);
+              compassHandlerRef.current = null;
+            }
+          };
+        }, []);
+
+        const [rows, setRows] = useState([]);
+        const [form, setForm] = useState({
+          carrier: 'Verizon',
+          location: 'Indoors',
+          bearing: 0,
+          down: '',
+          up: '',
+          lat: '',
+          rsrp: '',
+          sinr: '',
+          notes: '',
+        });
+
+        const canvasRef = useRef(null);
+        useSignalScene(canvasRef, {
+          verizonBearing: vzBearing,
+          attBearing: attBearing,
+          userFacingDeg: facing,
+          showATT,
+          showVerizon,
+        });
+
+        const chartData = useMemo(() => {
+          return rows
+            .filter((r) => r.address === address)
+            .map((r) => ({
+              angle: r.bearing,
+              down: Number(r.down || 0),
+              up: Number(r.up || 0),
+              latency: Number(r.lat || 0),
+              carrier: r.carrier,
+            }))
+            .sort((a, b) => a.angle - b.angle);
+        }, [rows, address]);
+
+        const radarData = useMemo(() => {
+          const agg = { N: 0, E: 0, S: 0, W: 0 };
+          rows
+            .filter((r) => r.address === address)
+            .forEach((r) => {
+              const ang = ((Number(r.bearing) % 360) + 360) % 360;
+              let quadrant = 'N';
+              if (ang >= 45 && ang < 135) {
+                quadrant = 'E';
+              } else if (ang >= 135 && ang < 225) {
+                quadrant = 'S';
+              } else if (ang >= 225 && ang < 315) {
+                quadrant = 'W';
+              }
+              const val = Number(r.down || 0);
+              if (val > agg[quadrant]) {
+                agg[quadrant] = val;
+              }
+            });
+          return ['N', 'E', 'S', 'W'].map((k) => ({ quadrant: k, Mbps: agg[k] }));
+        }, [rows, address]);
+
+        function addMeasurement() {
+          const clean = {
+            ts: Date.now(),
+            address,
+            carrier: form.carrier,
+            location: form.location,
+            bearing: clamp(Number(form.bearing), 0, 360),
+            down: Number(form.down),
+            up: Number(form.up),
+            lat: Number(form.lat),
+            rsrp: Number(form.rsrp),
+            sinr: Number(form.sinr),
+            notes: form.notes,
+          };
+          setRows((old) => [...old, clean]);
+        }
+
+        function removeRow(index) {
+          setRows((old) => old.filter((_, idx) => idx !== index));
+        }
+
+        return (
+          <div className="min-h-screen w-full bg-neutral-950 text-neutral-100">
+            <div className="max-w-7xl mx-auto p-4 md:p-6">
+              <header className="flex flex-col md:flex-row items-start md:items-center justify-between gap-3">
+                <h1 className="text-2xl md:text-3xl font-semibold tracking-tight">
+                  5G Window Placement Simulator — Wilmington &amp; Leland
+                </h1>
+                <div className="flex items-center gap-2 text-xs md:text-sm text-neutral-400">
+                  <span>Rotate the 3D scene, align your compass, log tests, and export CSV.</span>
+                </div>
+              </header>
+
+              <section className="mt-4 grid grid-cols-1 lg:grid-cols-3 gap-4">
+                <div className="bg-neutral-900/70 rounded-2xl p-4 shadow">
+                  <div className="font-semibold mb-2">Address</div>
+                  <select
+                    value={address}
+                    onChange={(e) => setAddress(e.target.value)}
+                    className="w-full bg-neutral-800 rounded-xl p-2 outline-none"
+                  >
+                    {Object.keys(TOWER_PRESETS).map((k) => (
+                      <option key={k} value={k}>
+                        {k}
+                      </option>
+                    ))}
+                  </select>
+                  <div className="mt-4 grid grid-cols-2 gap-3">
+                    <label className="text-sm">
+                      Verizon bearing
+                      <input
+                        type="number"
+                        min={0}
+                        max={360}
+                        value={vzBearing}
+                        onChange={(e) => setVzBearing(Number(e.target.value))}
+                        className="mt-1 w-full bg-neutral-800 rounded-lg p-2"
+                      />
+                    </label>
+                    <label className="text-sm">
+                      AT&amp;T bearing
+                      <input
+                        type="number"
+                        min={0}
+                        max={360}
+                        value={attBearing}
+                        onChange={(e) => setAttBearing(Number(e.target.value))}
+                        className="mt-1 w-full bg-neutral-800 rounded-lg p-2"
+                      />
+                    </label>
+                  </div>
+                  <div className="mt-3 flex items-center gap-4 text-sm">
+                    <label className="flex items-center gap-2">
+                      <input
+                        type="checkbox"
+                        checked={showVerizon}
+                        onChange={(e) => setShowVerizon(e.target.checked)}
+                      />
+                      <span>Show Verizon</span>
+                    </label>
+                    <label className="flex items-center gap-2">
+                      <input
+                        type="checkbox"
+                        checked={showATT}
+                        onChange={(e) => setShowATT(e.target.checked)}
+                      />
+                      <span>Show AT&amp;T</span>
+                    </label>
+                  </div>
+
+                  <div className="mt-6">
+                    <div className="font-semibold">Your facing (bearing)</div>
+                    <input
+                      type="range"
+                      min={0}
+                      max={360}
+                      value={facing}
+                      onChange={(e) => setFacing(Number(e.target.value))}
+                      className="w-full"
+                    />
+                    <div className="flex items-center justify-between text-sm mt-1">
+                      <span>{Math.round(facing)}°</span>
+                      <div className="flex items-center gap-2">
+                        {!useCompass ? (
+                          <button
+                            onClick={requestCompass}
+                            className="bg-emerald-600 hover:bg-emerald-500 transition px-3 py-1 rounded-lg"
+                          >
+                            Use device compass
+                          </button>
+                        ) : (
+                          <button
+                            onClick={stopCompass}
+                            className="bg-neutral-700 hover:bg-neutral-600 transition px-3 py-1 rounded-lg"
+                          >
+                            Stop compass
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="bg-neutral-900/70 rounded-2xl p-2 shadow col-span-1 lg:col-span-2">
+                  <div className="relative w-full h-[360px] md:h-[460px] rounded-xl overflow-hidden">
+                    <canvas ref={canvasRef} className="w-full h-full block" />
+                    <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+                      <div className="relative w-64 h-64 opacity-60">
+                        <div className="absolute inset-0 rounded-full border border-neutral-600" />
+                        <div className="absolute top-0 left-1/2 -translate-x-1/2 -translate-y-1/2 text-xs">N</div>
+                        <div className="absolute bottom-0 left-1/2 -translate-x-1/2 translate-y-1/2 text-xs">S</div>
+                        <div className="absolute left-0 top-1/2 -translate-x-1/2 -translate-y-1/2 text-xs">W</div>
+                        <div className="absolute right-0 top-1/2 translate-x-1/2 -translate-y-1/2 text-xs">E</div>
+                      </div>
+                    </div>
+                  </div>
+                  <div className="text-xs text-neutral-400 px-2 py-2">
+                    Green ray = your current facing; red = Verizon tower marker; blue = AT&amp;T tower marker. Bearings are
+                    estimated—adjust them to match your field measurements.
+                  </div>
+                </div>
+              </section>
+
+              <section className="mt-6 grid grid-cols-1 lg:grid-cols-3 gap-4">
+                <div className="bg-neutral-900/70 rounded-2xl p-4 shadow">
+                  <div className="font-semibold mb-2">Log a measurement</div>
+                  <div className="grid grid-cols-2 gap-3 text-sm">
+                    <label>
+                      Carrier
+                      <select
+                        value={form.carrier}
+                        onChange={(e) => setForm({ ...form, carrier: e.target.value })}
+                        className="mt-1 w-full bg-neutral-800 rounded-lg p-2"
+                      >
+                        <option>Verizon</option>
+                        <option>AT&amp;T</option>
+                      </select>
+                    </label>
+                    <label>
+                      Location
+                      <select
+                        value={form.location}
+                        onChange={(e) => setForm({ ...form, location: e.target.value })}
+                        className="mt-1 w-full bg-neutral-800 rounded-lg p-2"
+                      >
+                        <option>Indoors</option>
+                        <option>Outdoors</option>
+                        <option>Window</option>
+                        <option>Upstairs</option>
+                      </select>
+                    </label>
+                    <label>
+                      Bearing (°)
+                      <input
+                        type="number"
+                        min={0}
+                        max={360}
+                        value={form.bearing}
+                        onChange={(e) => setForm({ ...form, bearing: e.target.value })}
+                        className="mt-1 w-full bg-neutral-800 rounded-lg p-2"
+                      />
+                    </label>
+                    <label>
+                      Down (Mbps)
+                      <input
+                        type="number"
+                        value={form.down}
+                        onChange={(e) => setForm({ ...form, down: e.target.value })}
+                        className="mt-1 w-full bg-neutral-800 rounded-lg p-2"
+                      />
+                    </label>
+                    <label>
+                      Up (Mbps)
+                      <input
+                        type="number"
+                        value={form.up}
+                        onChange={(e) => setForm({ ...form, up: e.target.value })}
+                        className="mt-1 w-full bg-neutral-800 rounded-lg p-2"
+                      />
+                    </label>
+                    <label>
+                      Latency (ms)
+                      <input
+                        type="number"
+                        value={form.lat}
+                        onChange={(e) => setForm({ ...form, lat: e.target.value })}
+                        className="mt-1 w-full bg-neutral-800 rounded-lg p-2"
+                      />
+                    </label>
+                    <label>
+                      RSRP (dBm)
+                      <input
+                        type="number"
+                        value={form.rsrp}
+                        onChange={(e) => setForm({ ...form, rsrp: e.target.value })}
+                        className="mt-1 w-full bg-neutral-800 rounded-lg p-2"
+                      />
+                    </label>
+                    <label>
+                      SINR (dB)
+                      <input
+                        type="number"
+                        value={form.sinr}
+                        onChange={(e) => setForm({ ...form, sinr: e.target.value })}
+                        className="mt-1 w-full bg-neutral-800 rounded-lg p-2"
+                      />
+                    </label>
+                    <label className="col-span-2">
+                      Notes
+                      <input
+                        value={form.notes}
+                        onChange={(e) => setForm({ ...form, notes: e.target.value })}
+                        className="mt-1 w-full bg-neutral-800 rounded-lg p-2"
+                      />
+                    </label>
+                  </div>
+                  <div className="mt-3 flex gap-2">
+                    <button
+                      onClick={addMeasurement}
+                      className="bg-indigo-600 hover:bg-indigo-500 transition px-3 py-2 rounded-lg text-sm"
+                    >
+                      Add entry
+                    </button>
+                    <button
+                      onClick={() => downloadCSV(rows)}
+                      className="bg-neutral-800 hover:bg-neutral-700 transition px-3 py-2 rounded-lg text-sm"
+                    >
+                      Export CSV
+                    </button>
+                  </div>
+                  <div className="text-xs text-neutral-500 mt-2">
+                    Pro tip: On iPhone, open Field Test (*3001#12345#*) → NR Serving Cell → note RSRP/RSRQ/SINR while you face each
+                    direction.
+                  </div>
+                </div>
+
+                <div className="bg-neutral-900/70 rounded-2xl p-4 shadow">
+                  <div className="font-semibold mb-2">Speed vs Bearing (selected address)</div>
+                  <div className="h-56">
+                    <ResponsiveContainer width="100%" height="100%">
+                      <LineChart data={chartData} margin={{ top: 8, right: 12, left: 0, bottom: 8 }}>
+                        <CartesianGrid strokeDasharray="3 3" stroke="#333" />
+                        <XAxis
+                          dataKey="angle"
+                          type="number"
+                          domain={[0, 360]}
+                          tick={{ fill: '#aaa' }}
+                          label={{
+                            value: 'Bearing (°)',
+                            position: 'insideBottomRight',
+                            offset: -2,
+                            fill: '#aaa',
+                          }}
+                        />
+                        <YAxis
+                          yAxisId="left"
+                          tick={{ fill: '#aaa' }}
+                          label={{
+                            value: 'Down (Mbps)',
+                            angle: -90,
+                            position: 'insideLeft',
+                            fill: '#aaa',
+                          }}
+                        />
+                        <YAxis
+                          yAxisId="right"
+                          orientation="right"
+                          tick={{ fill: '#aaa' }}
+                          label={{
+                            value: 'Latency (ms)',
+                            angle: -90,
+                            position: 'insideRight',
+                            fill: '#aaa',
+                          }}
+                        />
+                        <Tooltip contentStyle={{ background: '#111', border: '1px solid #333' }} />
+                        <Legend />
+                        <Line
+                          yAxisId="left"
+                          type="monotone"
+                          dataKey="down"
+                          name="Down Mbps"
+                          dot={false}
+                          strokeWidth={2}
+                        />
+                        <Line
+                          yAxisId="right"
+                          type="monotone"
+                          dataKey="latency"
+                          name="Latency ms"
+                          dot={false}
+                          strokeDasharray="5 5"
+                          strokeWidth={1.5}
+                        />
+                      </LineChart>
+                    </ResponsiveContainer>
+                  </div>
+                  <div className="text-xs text-neutral-400 mt-2">
+                    Use this to see which bearing consistently yields the best throughput and lowest latency.
+                  </div>
+                </div>
+
+                <div className="bg-neutral-900/70 rounded-2xl p-4 shadow">
+                  <div className="font-semibold mb-2">Rose (Radar) — peak speed by quadrant</div>
+                  <div className="h-56">
+                    <ResponsiveContainer width="100%" height="100%">
+                      <RadarChart cx="50%" cy="50%" outerRadius="80%" data={radarData}>
+                        <PolarGrid stroke="#333" />
+                        <PolarAngleAxis dataKey="quadrant" tick={{ fill: '#aaa' }} />
+                        <PolarRadiusAxis tick={{ fill: '#aaa' }} />
+                        <Radar name="Mbps" dataKey="Mbps" stroke="#60a5fa" fill="#60a5fa" fillOpacity={0.4} />
+                        <Tooltip contentStyle={{ background: '#111', border: '1px solid #333' }} />
+                      </RadarChart>
+                    </ResponsiveContainer>
+                  </div>
+                  <div className="text-xs text-neutral-400 mt-2">
+                    Max download speed landed in each quadrant — aim windows toward the quadrant with the strongest results.
+                  </div>
+                </div>
+              </section>
+
+              <section className="mt-6">
+                <div className="bg-neutral-900/70 rounded-2xl p-4 shadow">
+                  <div className="font-semibold mb-3">Your measurements</div>
+                  <div className="overflow-x-auto">
+                    <table className="min-w-full text-sm">
+                      <thead className="text-neutral-300">
+                        <tr className="border-b border-neutral-800">
+                          <th className="text-left py-2 pr-4">Time</th>
+                          <th className="text-left py-2 pr-4">Address</th>
+                          <th className="text-left py-2 pr-4">Carrier</th>
+                          <th className="text-right py-2 pr-4">Bearing°</th>
+                          <th className="text-left py-2 pr-4">Loc</th>
+                          <th className="text-right py-2 pr-4">Down</th>
+                          <th className="text-right py-2 pr-4">Up</th>
+                          <th className="text-right py-2 pr-4">Latency</th>
+                          <th className="text-right py-2 pr-4">RSRP</th>
+                          <th className="text-right py-2 pr-4">SINR</th>
+                          <th className="text-left py-2 pr-4">Notes</th>
+                          <th className="text-left py-2 pr-4">Actions</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {rows.length === 0 ? (
+                          <tr>
+                            <td colSpan={12} className="py-6 text-neutral-500">
+                              No measurements yet. Take a walk to the window, face a bearing, run a speed test, log it here.
+                            </td>
+                          </tr>
+                        ) : (
+                          rows.map((r, i) => (
+                            <tr key={i} className="border-b border-neutral-900/60">
+                              <td className="py-1 pr-4">{new Date(r.ts).toLocaleTimeString()}</td>
+                              <td className="py-1 pr-4">{r.address}</td>
+                              <td className="py-1 pr-4">{r.carrier}</td>
+                              <td className="py-1 pr-4 text-right">{r.bearing}</td>
+                              <td className="py-1 pr-4">{r.location}</td>
+                              <td className="py-1 pr-4 text-right">{r.down}</td>
+                              <td className="py-1 pr-4 text-right">{r.up}</td>
+                              <td className="py-1 pr-4 text-right">{r.lat}</td>
+                              <td className="py-1 pr-4 text-right">{r.rsrp}</td>
+                              <td className="py-1 pr-4 text-right">{r.sinr}</td>
+                              <td className="py-1 pr-4">{r.notes}</td>
+                              <td className="py-1 pr-4">
+                                <button
+                                  onClick={() => removeRow(i)}
+                                  className="bg-neutral-800 hover:bg-neutral-700 transition px-2 py-1 rounded"
+                                >
+                                  Delete
+                                </button>
+                              </td>
+                            </tr>
+                          ))
+                        )}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              </section>
+
+              <footer className="py-8 text-xs text-neutral-500">
+                Bearings are illustrative and should be verified with on-site measurements (field test metrics, walk-tests).
+                Speeds and latency vary by time of day, congestion, firmware, and device bands. Use Wi‑Fi Calling for indoor dead
+                zones. If Verizon 5G Home is eligible, try window-facing placement toward the Verizon marker; rotate gateway for
+                peak SINR.
+              </footer>
+            </div>
+          </div>
+        );
+      }
+
+      const rootElement = document.getElementById('root');
+      if (rootElement) {
+        const root = ReactDOM.createRoot(rootElement);
+        root.render(<WindowPlacementSimulator />);
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a Tailwind-styled static index.html that renders the 5G window placement simulator
- build the Three.js scene, compass handling, CSV export, and analytics charts directly in the static bundle

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8bc3342848322ba5796c01e66bd2e