### PR TITLE
Ensure teardown callbacks fire after MiniFlask requests

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,8 +1,11 @@
 import os
 import sys
+from typing import Optional
+
+import pytest
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-from app import create_app
+from app import Flask, create_app
 
 
 def test_healthz():
@@ -29,3 +32,51 @@ def test_static_index_served(tmp_path):
 def test_db_dir_exists():
     flask_app = create_app()
     assert os.path.isdir(flask_app.config['DB_DIR'])
+
+
+def test_teardown_runs_after_request():
+    flask_app = create_app()
+    teardown_state = {"called": False, "exception": object()}
+
+    @flask_app.teardown_appcontext
+    def record(exc):
+        teardown_state["called"] = True
+        teardown_state["exception"] = exc
+
+    client = flask_app.test_client()
+    resp = client.get('/healthz')
+
+    assert resp.status_code == 200
+    assert teardown_state["called"] is True
+    assert teardown_state["exception"] is None
+
+
+def test_teardown_receives_exception():
+    flask_app = Flask(__name__)
+    if hasattr(flask_app, "config"):
+        flask_app.config['TESTING'] = True
+        flask_app.config['PROPAGATE_EXCEPTIONS'] = True
+    if hasattr(flask_app, "testing"):
+        flask_app.testing = True
+    captured = {"called": False, "exception": None}
+
+    @flask_app.route('/boom')
+    def boom():
+        raise RuntimeError('boom')
+
+    @flask_app.teardown_appcontext
+    def record(exc):
+        captured["called"] = True
+        captured["exception"] = exc
+
+    client = flask_app.test_client()
+    raised: Optional[BaseException] = None
+    try:
+        client.get('/boom')
+    except RuntimeError as exc:  # pragma: no cover - depends on Flask availability
+        raised = exc
+
+    assert captured["called"] is True
+    assert isinstance(captured["exception"], RuntimeError)
+    if raised is not None:
+        assert captured["exception"] is raised


### PR DESCRIPTION
## Summary
- wrap MiniFlask request dispatching in a try/finally so teardown callbacks run with the raised exception or None
- add regression tests asserting teardown hooks execute after successful requests and when a view raises

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5d4fdb158832286c0c7e9920029e7