### PR TITLE
Tweak save error handling in HealthLogModal

### DIFF
--- a/frontend/components/plant/HealthLogModal.jsx
+++ b/frontend/components/plant/HealthLogModal.jsx
@@ -19,6 +19,7 @@ export const HealthLogModal = ({ firestore, userId, plantId, onClose }) => {
   const [userNotes, setUserNotes] = useState('');
   const [previewImage, setPreviewImage] = useState(null);
   const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState(null);
   const [{ status: aiStatus, payload: aiPayload, error: aiError }, setAiState] =
     useState(initialAiState);
   const abortControllerRef = useRef(null);
@@ -64,6 +65,7 @@ export const HealthLogModal = ({ firestore, userId, plantId, onClose }) => {
     if (!previewImage || !firestore) {
       return;
     }
+    setSaveError(null);
     setIsSaving(true);
 
     try {
@@ -75,8 +77,9 @@ export const HealthLogModal = ({ firestore, userId, plantId, onClose }) => {
         createdAt: Timestamp.now(),
       });
       onClose();
-    } catch (saveError) {
-      console.error('Failed to save health log', saveError);
+    } catch (error) {
+      console.error('Failed to save health log', error);
+      setSaveError(error);
     } finally {
       setIsSaving(false);
     }
@@ -159,6 +162,12 @@ export const HealthLogModal = ({ firestore, userId, plantId, onClose }) => {
               </div>
             </div>
           </div>
+        )}
+
+        {saveError && (
+          <p className="text-sm text-red-600">
+            Unable to save this log. Please try again.
+          </p>
         )}
 
         <div className="flex justify-end gap-3 pt-4">


### PR DESCRIPTION
### Motivation
- Fix a variable shadowing bug in the save error handler so the `saveError` state is set correctly.
- Ensure save failures are captured and surfaced to the user instead of silently failing.
- Keep the modal open on save failure so users can retry or adjust data.
- Improve UX by showing a visible error message near the save controls.

### Description
- Added `saveError` state with `const [saveError, setSaveError] = useState(null);` to track save failures.
- Clear `saveError` at the start of `handleSave` using `setSaveError(null)` and set `isSaving` while saving.
- Renamed the catch parameter to `error`, log it with `console.error`, and call `setSaveError(error)` to avoid shadowing.
- Render a visible error message when `saveError` is set that reads "Unable to save this log. Please try again.".

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e6aa943a08322a83534e5a5c341d4)