### PR TITLE
HealthLogModal: defensive AI fallbacks and save error UI; fix Gemini API endpoint

### DIFF
--- a/frontend/utils/ai.js
+++ b/frontend/utils/ai.js
@@ -1,5 +1,5 @@
 const MODEL_URL =
-  'https://generativanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-09-2025:generateContent';
+  'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-09-2025:generateContent';
 
 const SYSTEM_PROMPT = `You are 'Flora,' an expert botanist and plant health diagnostician. A user is providing an image (as Base64 data) and text notes about their houseplant. Your task is to analyze these inputs and provide a concise, helpful diagnosis and care plan. Respond only in JSON that matches the response schema. Identify the plant if possible. Be encouraging and clear.`;
 


### PR DESCRIPTION
### Motivation
- Prevent runtime errors and a broken UI when the AI analysis response omits expected fields in `aiPayload`.
- Make save failures visible to users so they know when a health log did not persist.
- Ensure the frontend can reach the Gemini model by correcting the API hostname in `MODEL_URL`.

### Description
- Fixed a typo in the Gemini API hostname in `frontend/utils/ai.js` by updating `MODEL_URL` to the correct `generativelanguage` host.
- Added `saveError` state and cleared it at the start of `handleSave`, and set it when a save fails so the modal displays an error message above action buttons.
- Introduced memoized, defensive `potentialIssues` and `careRecommendations` arrays derived from `aiPayload` with `Array.isArray` fallbacks, and added user-friendly empty-state list items and a fallback summary message.
- Updated `HealthLogModal.jsx` to use the defensive values and avoid mapping over undefined fields, and to disable/indicate save state with `isSaving`.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e6a3459ec8322b2f3183fe36384cb)